### PR TITLE
Fix package requirements

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,1 +1,0 @@
-pycparser==2.18

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     author='SourceBots',
     license='MIT',
     install_requires=[],
-    dependency_links=['git+ssh://git@github.com/sourcebots/robotd.git#egg=robotd'],
-    tests_require=[],
+    dependency_links=[],
+    tests_require=["robotd", "sb-vision"],
     packages=find_packages(exclude=['contrib', 'docs', 'tests']),
 )


### PR DESCRIPTION
For some reason the `requirements_test.txt` file listed `pycparser` as a requirement, although its never used anywhere. I presume this was left over from an earlier time?

Also, the tests require `robotd` and `sb-vision` to be available.

I've unfamiliar with python packaging idioms - have I done this correctly?