### PR TITLE
Explicit Robot and Board close handling

### DIFF
--- a/robot/board.py
+++ b/robot/board.py
@@ -144,12 +144,10 @@ class Board:
         self.send(message, should_retry)
         return self.receive(should_retry)
 
-    def __del__(self):
-        self._clean_up()
-
-    def _clean_up(self):
+    def close(self):
+        """
+        Close the the connection to the underlying robotd board.
+        """
         self.socket.detach()
 
-    def __del__(self):
-        self._clean_up()
-
+    __del__ = close

--- a/robot/robot.py
+++ b/robot/robot.py
@@ -180,6 +180,9 @@ class Robot:
         return self._game.mode
 
     def close(self):
+        """
+        Close all the baord connections this instance holds.
+        """
         # remove all the boards
         for board_type in self.all_known_boards:
             for board in board_type:

--- a/robot/robot.py
+++ b/robot/robot.py
@@ -183,8 +183,8 @@ class Robot:
         """
         Close all the baord connections this instance holds.
         """
-        for board_type in self.all_known_boards:
-            for board in board_type:
+        for board_group in self.all_known_boards:
+            for board in board_group:
                 board.close()
 
     def __del__(self):

--- a/robot/robot.py
+++ b/robot/robot.py
@@ -185,7 +185,7 @@ class Robot:
         """
         for board_type in self.all_known_boards:
             for board in board_type:
-                del board
+                board.close()
 
     def __del__(self):
         self.close()

--- a/robot/robot.py
+++ b/robot/robot.py
@@ -187,6 +187,10 @@ class Robot:
             for board in board_group:
                 board.close()
 
+            # Clear the group so that any further access doesn't accidentally
+            # reanimate the boards (which isn't supported).
+            del board_group[:]
+
     def __del__(self):
         self.close()
 

--- a/robot/robot.py
+++ b/robot/robot.py
@@ -183,7 +183,6 @@ class Robot:
         """
         Close all the baord connections this instance holds.
         """
-        # remove all the boards
         for board_type in self.all_known_boards:
             for board in board_type:
                 del board


### PR DESCRIPTION
Tidy how the `Robot` class closes its `Board`s and how they are closed.

This fixes an issue where previously nothing actually happened in `Robot.close` (see my [comment](https://github.com/sourcebots/robot-api/commit/e5f824289369c3deeda35f949fe0782582962f71#r26705712) for details).