### PR TITLE
Move some internal board methods to protected

### DIFF
--- a/robot/board.py
+++ b/robot/board.py
@@ -59,7 +59,7 @@ class Board:
             print('Error connecting to:', socket_path)
             raise e
 
-        greeting = self.receive()
+        greeting = self._receive()
         self._greeting_response(greeting)
 
     def _get_lc_error(self):
@@ -109,7 +109,7 @@ class Board:
 
         raise original_exception
 
-    def send(self, message, should_retry=True):
+    def _send(self, message, should_retry=True):
         """
         Send a message to robotd.
 
@@ -134,7 +134,7 @@ class Board:
             raise BrokenPipeError()
         return data
 
-    def receive(self, should_retry=True):
+    def _receive(self, should_retry=True):
         """
         Receive a message from robotd.
         """
@@ -155,17 +155,17 @@ class Board:
 
         return json.loads(line.decode('utf-8'))
 
-    def send_and_receive(self, message, should_retry=True):
+    def _send_and_receive(self, message, should_retry=True):
         """
         Send a message to robotd and wait for a response.
         """
-        self.send(message, should_retry)
-        return self.receive(should_retry)
+        self._send(message, should_retry)
+        return self._receive(should_retry)
 
-    def close(self):
+    def _close(self):
         """
         Close the the connection to the underlying robotd board.
         """
         self.socket.detach()
 
-    __del__ = close
+    __del__ = _close

--- a/robot/board.py
+++ b/robot/board.py
@@ -162,10 +162,10 @@ class Board:
         self._send(message, should_retry)
         return self._receive(should_retry)
 
-    def _close(self):
+    def close(self):
         """
         Close the the connection to the underlying robotd board.
         """
         self.socket.detach()
 
-    __del__ = _close
+    __del__ = close

--- a/robot/camera.py
+++ b/robot/camera.py
@@ -45,11 +45,11 @@ class Camera(Board):
         """
         abort_after = time.time() + 10
 
-        self.send({'see': True})
+        self._send({'see': True})
 
         while True:
             try:
-                return self._see_to_results(self.receive(should_retry=True))
+                return self._see_to_results(self._receive(should_retry=True))
             except socket.timeout:
                 if time.time() > abort_after:
                     raise

--- a/robot/game.py
+++ b/robot/game.py
@@ -33,14 +33,14 @@ class GameState(Board):
 
         :return: zone ID the robot started in (0-3)
         """
-        return self.send_and_receive({})['zone']
+        return self._send_and_receive({})['zone']
 
     @property
     def mode(self):
         """
         :return: The ``GameMode`` that the robot is currently in.
         """
-        value = self.send_and_receive({})['mode']
+        value = self._send_and_receive({})['mode']
         for enum in GameMode:
             if value == enum.value:
                 return enum

--- a/robot/motor.py
+++ b/robot/motor.py
@@ -84,7 +84,7 @@ class MotorBoard(Board):
 
     def _get_status(self, motor_id):
         return self._string_to_power(
-            self.send_and_receive({})[motor_id],
+            self._send_and_receive({})[motor_id],
         )
 
     def _update_motor(self, motor_id, voltage):
@@ -95,4 +95,4 @@ class MotorBoard(Board):
         :param voltage: Voltage to set the motor to
         """
         v_string = self._power_to_string(voltage)
-        self.send_and_receive({motor_id: v_string})
+        self._send_and_receive({motor_id: v_string})

--- a/robot/power.py
+++ b/robot/power.py
@@ -31,17 +31,17 @@ class PowerBoard(Board):
         Turn on power to all power board outputs.
         """
 
-        self.send_and_receive({'power': True})
+        self._send_and_receive({'power': True})
 
     def power_off(self):
         """
         Turn off power to all power board outputs.
         """
-        self.send_and_receive({'power': False})
+        self._send_and_receive({'power': False})
 
     def set_start_led(self, value):
         """Set the state of the start LED."""
-        self.send_and_receive({'start-led': bool(value)})
+        self._send_and_receive({'start-led': bool(value)})
 
     @property
     def start_button_pressed(self):
@@ -49,7 +49,7 @@ class PowerBoard(Board):
         Read the status of the start button.
         """
 
-        status = self.send_and_receive({})
+        status = self._send_and_receive({})
         return status["start-button"]
 
     def buzz(self, duration, *, note=None, frequency=None):
@@ -62,7 +62,7 @@ class PowerBoard(Board):
             frequency = self.BUZZ_NOTES[note.lower()]
         if frequency is None:
             raise ValueError("Invalid frequency")
-        self.send_and_receive({'buzz': {
+        self._send_and_receive({'buzz': {
             'frequency': frequency,
             'duration': int(duration * 1000),
         }})

--- a/robot/servo.py
+++ b/robot/servo.py
@@ -127,10 +127,10 @@ class ServoBoard(Board):
         return self._servos
 
     def _set_servo_pos(self, servo, pos):
-        self.send_and_receive({'servos': {servo: pos}})
+        self._send_and_receive({'servos': {servo: pos}})
 
     def _get_servo_pos(self, servo):
-        data = self.send_and_receive({})
+        data = self._send_and_receive({})
         values = data['servos']
         return values[str(servo)]
 
@@ -142,26 +142,26 @@ class ServoBoard(Board):
 
     def _read_pin(self, pin):
         # request a check for that pin by trying to set it to None
-        data = self.send_and_receive({'read-pins': [pin]})
+        data = self._send_and_receive({'read-pins': [pin]})
         # example data value:
         # {'pin-values':{2:'high'}}
         values = data['pin-values']
         return PinValue(values[str(pin)])
 
     def _get_pin_mode(self, pin):
-        data = self.send_and_receive({})
+        data = self._send_and_receive({})
         # example data value:
         # {'pins':{2:'pullup'}}
         values = data['pins']
         return PinMode(values[str(pin)])
 
     def _set_pin_mode(self, pin, value: PinMode):
-        self.send_and_receive({'pins': {pin: value.value}})
+        self._send_and_receive({'pins': {pin: value.value}})
 
     def read_analogue(self):
         """Read analogue values from the connected board."""
         command = {'read-analogue': True}
-        return self.send_and_receive(command)['analogue-values']
+        return self._send_and_receive(command)['analogue-values']
 
     def read_ultrasound(self, trigger_pin, echo_pin):
         """
@@ -173,4 +173,4 @@ class ServoBoard(Board):
                          echo pin is connected to.
         """
         command = {'read-ultrasound': [trigger_pin, echo_pin]}
-        return self.send_and_receive(command)['ultrasound']
+        return self._send_and_receive(command)['ultrasound']


### PR DESCRIPTION
Some internal methods for a board are public.
namely:
`send`, `receive`, `close`, and `send_and_receive`.
This can cause problems with students, as they assume they might
want to call the function.

Change the public methods of `Board` to be protected, to fix the
aforementioned issue.