### PR TITLE
Fix issues with making socket_path a Path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
     docker:
       # specify the version you desire here
       # use `-browsers` prefix for selenium tests, e.g. `3.6.1-browsers`
-      - image: python:3.4-jessie
+      - image: python:3-stretch
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images

--- a/robot/board.py
+++ b/robot/board.py
@@ -3,6 +3,7 @@ import socket
 import time
 from collections import Mapping
 from pathlib import Path
+from typing import Union
 
 
 class BoardList(Mapping):
@@ -30,7 +31,7 @@ class Board:
     SEND_TIMEOUT_SECS = 6
     RECV_BUFFER_BYTES = 2048
 
-    def __init__(self, socket_path):
+    def __init__(self, socket_path: Union[Path, str]):
         self.socket_path = Path(socket_path)
         self.socket = None
         self.data = b''

--- a/robot/robot.py
+++ b/robot/robot.py
@@ -1,5 +1,6 @@
 import time
 from pathlib import Path
+from typing import Set  # noqa: F401
 
 from robot.board import BoardList
 from robot.camera import Camera
@@ -63,9 +64,9 @@ class Robot:
         :param directory_name:
         :return:
         """
-        known_paths = {x.socket_path for x in known_boards}
-        boards_dir = self.robotd_path / directory_name
-        new_paths = {str(x) for x in boards_dir.glob('*')}
+        known_paths = {x.socket_path for x in known_boards}  # type: Set[Path]
+        boards_dir = self.robotd_path / directory_name  # type: Path
+        new_paths = {str(x) for x in boards_dir.glob('*')}  # type: Set[str]
         boards = known_boards[:]
         # Add all boards that weren't previously there
         for board in new_paths - known_paths:

--- a/robot/robot.py
+++ b/robot/robot.py
@@ -69,14 +69,14 @@ class Robot:
         new_paths = {str(x) for x in boards_dir.glob('*')}  # type: Set[str]
         boards = known_boards[:]
         # Add all boards that weren't previously there
-        for board in new_paths - known_paths:
-            print("New board found:", board)
+        for board_path in new_paths - known_paths:
+            print("New board found:", board_path)
 
             try:
-                new_board = board_type(board)
+                new_board = board_type(board_path)
                 boards.append(new_board)
             except (FileNotFoundError, ConnectionRefusedError) as e:
-                print("Could not connect to the board:", board, e)
+                print("Could not connect to the board:", board_path, e)
 
         return sorted(boards, key=lambda b: b.serial)
 

--- a/robot/robot.py
+++ b/robot/robot.py
@@ -66,7 +66,7 @@ class Robot:
         """
         known_paths = {x.socket_path for x in known_boards}  # type: Set[Path]
         boards_dir = self.robotd_path / directory_name  # type: Path
-        new_paths = {str(x) for x in boards_dir.glob('*')}  # type: Set[str]
+        new_paths = {x for x in boards_dir.glob('*')}  # type: Set[Path]
         boards = known_boards[:]
         # Add all boards that weren't previously there
         for board_path in new_paths - known_paths:


### PR DESCRIPTION
Following @kierdavis' [investigation](https://github.com/sourcebots/robot-api/pull/22#issuecomment-360309918) into the issues with changing the `socket_path` to being a `Path` this introduces types in a couple of places where `socket_path` is used in a non-trivial manner (i.e: not places where we're just passing it through to something else; 
6cb4ec7 and aadbaad), renames a variable for clarity (7bdc970) and then introduces a fix (959cf47).

I suggest reviewing by commit -- I've design them so that after reading the tidyups the fix should be obvious and self-explanatory.