### PR TITLE
Remove marker size

### DIFF
--- a/robot/markers.py
+++ b/robot/markers.py
@@ -77,11 +77,6 @@ class Marker:
         """ID of the marker seen."""
         return self._raw_data['id']
 
-    @property
-    def size(self) -> Tuple[Metres, Metres]:
-        """Marker size in metres."""
-        return self._raw_data['size']
-
     # Disabled because it's always 0.0
     # TODO fix the certainty being 0
     # @property


### PR DESCRIPTION
This never worked -- it would always have emitted a `KeyError`. Remove it so that we don't need to document it or make it work. If we add it later, we can add docs etc. then.