### PR TITLE
Fix race condition in power board tests

### DIFF
--- a/tests/mock_robotd.py
+++ b/tests/mock_robotd.py
@@ -15,6 +15,10 @@ class MockBoardMixin:
         self.message_queue = Queue()
 
     def clear_queue(self):
+        # If run from the main process, wait some time for the board runner
+        # process to decode and enqueue any commands waiting in the socket
+        # buffer before we check whether the queue is empty or not.
+        time.sleep(0.2)
         while not self.message_queue.empty():
             self.message_queue.get()
 


### PR DESCRIPTION
See inline comment.

This fixes race conditions in the `test_buzz_message` and `test_fractional_buzz_duration` power board tests.

Previously, `clear_queue` would be called immediately after initialising the `Robot` instance. If the board runner subprocess hasn't had time to decode the packets sent by `Robot.__init__` before `clear_queue` was called, then these packets will end up at the head of the queue *after* the call to `clear_queue`. This means that the check to see if the packet at the head of the queue is `buzz` packet sometimes fails, depending on the nondeterministicness of the process scheduler.