### PR TITLE
Rework robotd JSON connections

### DIFF
--- a/robot/board.py
+++ b/robot/board.py
@@ -11,7 +11,7 @@ LOGGER = logging.getLogger(__name__)
 class Board:
     """Base class for connections to ``robotd`` board sockets."""
 
-    SEND_TIMEOUT_SECS = 6
+    CONNECTION_TIMEOUT_SECS = 6
 
     def __init__(self, socket_path: Union[Path, str]) -> None:
         self.socket_path = Path(socket_path)
@@ -40,7 +40,7 @@ class Board:
         :param socket_path: Path for the unix socket
         """
         self.socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        self.socket.settimeout(self.SEND_TIMEOUT_SECS)
+        self.socket.settimeout(self.CONNECTION_TIMEOUT_SECS)
 
         try:
             self.socket.connect(str(self.socket_path))

--- a/robot/board.py
+++ b/robot/board.py
@@ -12,7 +12,6 @@ class Board:
     """Base class for connections to ``robotd`` board sockets."""
 
     SEND_TIMEOUT_SECS = 6
-    RECV_BUFFER_BYTES = 2048
 
     def __init__(self, socket_path: Union[Path, str]) -> None:
         self.socket_path = Path(socket_path)

--- a/robot/board.py
+++ b/robot/board.py
@@ -98,11 +98,10 @@ class Board:
 
         raise original_exception
 
-    def _send(self, message, should_retry=True):
+    def _send(self, message):
         """
         Send a message to robotd.
 
-        :param retry: used internally
         :param message: message to send
         """
 
@@ -111,10 +110,7 @@ class Board:
         def sendall():
             self.socket.sendall(data)
 
-        if should_retry:
-            return self._socket_with_single_retry(sendall)
-        else:
-            return sendall()
+        return self._socket_with_single_retry(sendall)
 
     def _recv_from_socket(self, size):
         data = self.socket.recv(size)
@@ -122,17 +118,14 @@ class Board:
             raise BrokenPipeError()
         return data
 
-    def _receive(self, should_retry=True):
+    def _receive(self):
         """
         Receive a message from robotd.
         """
         while b'\n' not in self.data:
-            if should_retry:
-                message = self._socket_with_single_retry(
-                    lambda: self._recv_from_socket(4096),
-                )
-            else:
-                message = self._recv_from_socket(4096)
+            message = self._socket_with_single_retry(
+                lambda: self._recv_from_socket(4096),
+            )
 
             self.data += message
 
@@ -141,12 +134,12 @@ class Board:
 
         return json.loads(line.decode('utf-8'))
 
-    def _send_and_receive(self, message, should_retry=True):
+    def _send_and_receive(self, message):
         """
         Send a message to robotd and wait for a response.
         """
-        self._send(message, should_retry)
-        return self._receive(should_retry)
+        self._send(message)
+        return self._receive()
 
     def close(self):
         """

--- a/robot/camera.py
+++ b/robot/camera.py
@@ -69,7 +69,7 @@ class Camera(Board):
 
         while True:
             try:
-                return self._see_to_results(self._receive(should_retry=True))
+                return self._see_to_results(self._receive())
             except socket.timeout:
                 if time.time() > abort_after:
                     raise

--- a/robot/connection.py
+++ b/robot/connection.py
@@ -1,0 +1,42 @@
+import json
+import socket
+from typing import Any, Dict
+
+Message = Dict[str, Any]
+
+
+class Connection:
+    """
+    A connection to a device.
+
+    This wraps a ``socket.socket`` providing encoding and decoding so that
+    consumers of this class can send and receive JSON-compatible typed data
+    rather than needing to worry about lower-level details.
+    """
+
+    def __init__(self, socket: socket.socket) -> None:
+        """Wrap the given socket."""
+        self.socket = socket
+        self.data = b''
+
+    def close(self) -> None:
+        """Close the connection."""
+        self.socket.close()
+
+    def send(self, message: Message) -> None:
+        """Send the given JSON-compatible message over the connection."""
+        line = json.dumps(message).encode('utf-8') + b'\n'
+        self.socket.sendall(line)
+
+    def receive(self) -> Message:
+        """Receive a single message from the connection."""
+        while b'\n' not in self.data:
+            message = self.socket.recv(4096)
+            if message == b'':
+                raise BrokenPipeError()
+
+            self.data += message
+        line = self.data.split(b'\n', 1)[0]
+        self.data = self.data[len(line) + 1:]
+
+        return json.loads(line.decode('utf-8'))


### PR DESCRIPTION
This is an attempt to both simplify the logic around the JSON sockets connecting robot-api to robotd and to prepare their usage for having type hints added.

The main unknown I'm facing is not really understanding what real-world scenarios each of the exceptions we currently catch relate to, and thus whether there is anything sensible that we can do in each case.

This branch begins to assume that if we reconnect a socket that we should recommence our instruction cycle with the backend, though doesn't apply this consistently. It's not clear to me how reliable this expectation is; in particular how it affect reconnections which occur in the middle of `_send_and_receive`.