### PR TITLE
Simplify board lists

### DIFF
--- a/robot/board.py
+++ b/robot/board.py
@@ -3,7 +3,7 @@ import logging
 import socket
 import time
 from pathlib import Path
-from typing import Mapping, TypeVar, Union
+from typing import Iterable, Mapping, TypeVar, Union
 
 LOGGER = logging.getLogger(__name__)
 
@@ -167,8 +167,8 @@ TBoard = TypeVar('TBoard', bound=Board)
 class BoardList(Mapping[Union[str, int], TBoard]):
     """A mapping of ``Board``s allowing access by index or identity."""
 
-    def __init__(self, *args, **kwargs):
-        self._store = dict(*args, **kwargs)
+    def __init__(self, boards: Iterable[TBoard]) -> None:
+        self._store = {x.serial: x for x in boards}
         self._store_list = sorted(self._store.values(), key=lambda board: board.serial)
 
     def __getitem__(self, attr: Union[str, int]) -> TBoard:

--- a/robot/robot.py
+++ b/robot/robot.py
@@ -84,7 +84,7 @@ class Robot:
                     exc_info=True,
                 )
 
-        return sorted(boards, key=lambda b: b.serial)
+        return boards
 
     @staticmethod
     def _dictify_boards(boards: List[TBoard]) -> BoardList[TBoard]:

--- a/robot/robot.py
+++ b/robot/robot.py
@@ -86,11 +86,6 @@ class Robot:
 
         return boards
 
-    @staticmethod
-    def _dictify_boards(boards: List[TBoard]) -> BoardList[TBoard]:
-        # Convert lists of boards into a dictionary
-        return BoardList({board.serial: board for board in boards})
-
     # TODO: Parameterise the functions below so we only need one
     @property
     def motor_boards(self) -> BoardList[MotorBoard]:
@@ -99,7 +94,7 @@ class Robot:
         """
         boards = self._update_boards(self.known_motor_boards, MotorBoard, 'motor')
         self.known_motor_boards = boards
-        return self._dictify_boards(boards)
+        return BoardList(boards)
 
     @property
     def power_boards(self) -> BoardList[PowerBoard]:
@@ -108,7 +103,7 @@ class Robot:
         """
         boards = self._update_boards(self.known_power_boards, PowerBoard, 'power')
         self.known_power_boards = boards
-        return self._dictify_boards(boards)
+        return BoardList(boards)
 
     @property
     def servo_boards(self) -> BoardList[ServoBoard]:
@@ -121,7 +116,7 @@ class Robot:
             'servo_assembly',
         )
         self.known_servo_boards = boards
-        return self._dictify_boards(boards)
+        return BoardList(boards)
 
     @property
     def cameras(self) -> BoardList[Camera]:
@@ -130,7 +125,7 @@ class Robot:
         """
         boards = self._update_boards(self.known_cameras, Camera, 'camera')
         self.known_cameras = boards
-        return self._dictify_boards(boards)
+        return BoardList(boards)
 
     @property
     def _games(self) -> BoardList[GameState]:
@@ -139,7 +134,7 @@ class Robot:
         """
         boards = self._update_boards(self.known_gamestates, GameState, 'game')
         self.known_gamestates = boards
-        return self._dictify_boards(boards)
+        return BoardList(boards)
 
     @staticmethod
     def _single_index(name, list_of_boards: BoardList[TBoard]) -> TBoard:

--- a/robot/robot.py
+++ b/robot/robot.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import List, Set, Union  # noqa: F401
+from typing import List, Set, Type, Union  # noqa: F401
 
 from robot.board import BoardList, TBoard
 from robot.camera import Camera
@@ -8,6 +8,8 @@ from robot.game import GameMode, GameState, Zone
 from robot.motor import MotorBoard
 from robot.power import PowerBoard
 from robot.servo import ServoBoard
+
+_PathLike = Union[str, Path]
 
 LOGGER = logging.getLogger(__name__)
 
@@ -27,7 +29,7 @@ class Robot:
 
     def __init__(
         self,
-        robotd_path: Union[str, Path]=ROBOTD_ADDRESS,
+        robotd_path: _PathLike=ROBOTD_ADDRESS,
         wait_for_start_button: bool=True,
     ) -> None:
         self.robotd_path = Path(robotd_path)
@@ -57,14 +59,20 @@ class Robot:
         if not power_boards:
             raise RuntimeError('Cannot find Power Board!')
 
-    def _update_boards(self, known_boards, board_type, directory_name):
+    def _update_boards(
+        self,
+        known_boards: List[TBoard],
+        board_type: Type[TBoard],
+        directory_name: _PathLike,
+    ) -> List[TBoard]:
         """
         Update the number of boards against the known boards.
 
-        :param known_boards:
-        :param board_type:
-        :param directory_name:
-        :return:
+        :param known_boards: The list of all currently known boards.
+        :param board_type: The type of board to create.
+        :param directory_name: The relative directory to look in for new boards.
+        :return: A list of all the known boards (both previously known and newly
+                 found).
         """
         known_paths = {x.socket_path for x in known_boards}  # type: Set[Path]
         boards_dir = self.robotd_path / directory_name  # type: Path


### PR DESCRIPTION
This changes `_update_boards` so that it handles all the logic needed by the various boards properties and resolves the TODO around that. It also moves more of the logic around the construction of `BoardList` into that class, making it simpler to create and to add types for.