### PR TITLE
Collect the board lists only when needed

### DIFF
--- a/robot/robot.py
+++ b/robot/robot.py
@@ -38,14 +38,6 @@ class Robot:
         self.known_gamestates = []  # type: List[GameState]
 
         LOGGER.info("Initializing Hardware...")
-        self.all_known_boards = [
-            self.known_power_boards,
-            self.known_motor_boards,
-            self.known_servo_boards,
-            self.known_cameras,
-            self.known_gamestates,
-        ]
-
         self._assert_has_power_board()
         self.power_board.power_on()
 
@@ -219,7 +211,13 @@ class Robot:
         Cleanup robot instance.
         """
 
-        for board_group in self.all_known_boards:
+        for board_group in (
+            self.known_power_boards,
+            self.known_motor_boards,
+            self.known_servo_boards,
+            self.known_cameras,
+            self.known_gamestates,
+        ):
             for board in board_group:
                 board.close()
 


### PR DESCRIPTION
This ensures that they actually contain the lists of boards at this point, thus ensuring that we properly close off the boards.

Note: while it might be assumed that this could be done upfront, we reassign the `self.known*boards` attributes when adding boards, meaning that the upfront collection will only reflect the initial (empty) lists.

Note: the issues this fixes is also resolved by #79, though I think we still want this change for clarity.