### PR TITLE
Add Marker.__str__

### DIFF
--- a/robot/markers.py
+++ b/robot/markers.py
@@ -178,3 +178,12 @@ class Marker:
         space is different to the usual representation of a spherical space.
         """
         return SphericalCoord(*self._raw_data['spherical'])
+
+    def __str__(self):
+        bearing = self.spherical.rot_y_degrees
+        return "<Marker {}: {:.0f}° {}, {:.2f}m away>".format(
+            self.id,
+            abs(bearing),
+            "right" if bearing > 0 else "left",
+            self.distance_metres,
+        )

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -1,7 +1,7 @@
 import math
 import unittest
 
-from robot.markers import Metres, Radians, SphericalCoord
+from robot.markers import Metres, Radians, SphericalCoord, Marker
 
 
 class SphericalCoordTest(unittest.TestCase):
@@ -22,4 +22,34 @@ class SphericalCoordTest(unittest.TestCase):
             -45,
             coords.rot_y_degrees,
             "Wrong y rotation",
+        )
+
+
+class MarkerTest(unittest.TestCase):
+    def test_str_left(self):
+        data = {
+            'id': 13,
+            'spherical': [
+                0,  # rot_x
+                -0.21467549799530256,  # rot_y, -12.3 degrees
+                0.12,  # distance
+            ],
+        }
+        self.assertEqual(
+            str(Marker(data)),
+            "<Marker 13: 12° left, 0.12m away>",
+        )
+
+    def test_str_right(self):
+        data = {
+            'id': 13,
+            'spherical': [
+                0,  # rot_x
+                0.21467549799530256,  # rot_y, 12.3 degrees
+                0.12,  # distance
+            ],
+        }
+        self.assertEqual(
+            str(Marker(data)),
+            "<Marker 13: 12° right, 0.12m away>",
         )

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -1,7 +1,7 @@
 import math
 import unittest
 
-from robot.markers import Metres, Radians, SphericalCoord, Marker
+from robot.markers import Marker, Metres, Radians, SphericalCoord
 
 
 class SphericalCoordTest(unittest.TestCase):


### PR DESCRIPTION
While the position attributes mostly return `namedtuple`s which have nice representations automatically provided, the Marker class itself doesn't. Provide one so that it can trivially be printed.