### PR TITLE
add __repr__ for Board and Markers

### DIFF
--- a/robot/board.py
+++ b/robot/board.py
@@ -155,6 +155,9 @@ class Board:
         """
         self.socket.detach()
 
+    def __repr__(self):
+        return "<{}>".format(self.__str__())
+
     def __str__(self):
         return "{} - {}".format(self.__name__, self.serial)
 


### PR DESCRIPTION
Currently Board and Markers don't show pretty prints if you `print(markers)`. They do have `__str__()` functions, but `print()` calls `__repr__()`, so implement `__repr__()`