### PR TITLE
Deprecated is_wall_marker/is_token_marker methods

### DIFF
--- a/robot/markers.py
+++ b/robot/markers.py
@@ -123,14 +123,6 @@ class Marker:
         return self.spherical.distance_metres
 
     # Helper functions, Might need to vary these per-game
-    def is_wall_marker(self) -> bool:
-        """If the marker is a wall marker."""
-        return self.id in WALL
-
-    def is_token_marker(self) -> bool:
-        """If the marker is a token marker."""
-        return self.id in TOKEN
-
     @property
     def polar(self) -> PolarCoord:
         """

--- a/robot/markers.py
+++ b/robot/markers.py
@@ -120,7 +120,6 @@ class Marker:
         """Distance of the marker from the camera in metres."""
         return self.spherical.distance_metres
 
-    # Helper functions, Might need to vary these per-game
     @property
     def polar(self) -> PolarCoord:
         """

--- a/robot/markers.py
+++ b/robot/markers.py
@@ -2,8 +2,6 @@ import math
 import warnings
 from typing import List, NamedTuple, NewType, Tuple
 
-from robot.game_specific import TOKEN, WALL
-
 Metres = NewType('Metres', float)
 Degrees = NewType('Degrees', float)
 Radians = NewType('Radians', float)


### PR DESCRIPTION
https://trello.com/c/tHwRNdfo/63-deprecate-remove-iswallmarker-istokenmarker-methods
As agreed, we are deprecating is_wall_marker and is_token_marker and encouraging the use of marker.id instead of these two methods.

Docs removed in https://github.com/sourcebots/docs/pull/139