### PR TITLE
Add support for controlling separate power outputs on power board

### DIFF
--- a/robot/__init__.py
+++ b/robot/__init__.py
@@ -38,6 +38,7 @@ from robot.game_specific import (
     WALL,
 )
 from robot.motor import BRAKE, COAST
+from robot.power import PowerOutput
 from robot.robot import Robot
 from robot.servo import PinMode, PinValue
 
@@ -80,4 +81,5 @@ __all__ = (
     'Robot',
     'PinMode',
     'PinValue',
+    'PowerOutput',
 )

--- a/robot/power.py
+++ b/robot/power.py
@@ -1,7 +1,8 @@
+import enum
 import logging
 import time
 from typing import Callable
-import enum
+
 from robot.board import Board
 
 LOGGER = logging.getLogger(__name__)
@@ -56,8 +57,11 @@ class PowerBoard(Board):
         self._send_and_receive({'power': False})
 
     def set_output(self, output: PowerOutput, value: bool) -> None:
-        self.send_and_receive({
-            'power-output': output.value
+        """
+        Turn off individual power output.
+        """
+        self._send_and_receive({
+            'power-output': output.value,
             'power-level': value,
         })
 

--- a/robot/power.py
+++ b/robot/power.py
@@ -58,7 +58,7 @@ class PowerBoard(Board):
 
     def set_output(self, output: PowerOutput, value: bool) -> None:
         """
-        Turn off individual power output.
+        Turn on and off individual power outputs.
         """
         self._send_and_receive({
             'power-output': output.value,

--- a/robot/power.py
+++ b/robot/power.py
@@ -1,10 +1,22 @@
 import logging
 import time
 from typing import Callable
-
+import enum
 from robot.board import Board
 
 LOGGER = logging.getLogger(__name__)
+
+
+# Keep this in sync with `robotd`
+class PowerOutput(enum.Enum):
+    """An enumeration of the outputs on the power board."""
+
+    HIGH_POWER_1 = 0
+    HIGH_POWER_2 = 1
+    LOW_POWER_1 = 2
+    LOW_POWER_2 = 3
+    LOW_POWER_3 = 4
+    LOW_POWER_4 = 5
 
 
 class PowerBoard(Board):
@@ -42,6 +54,12 @@ class PowerBoard(Board):
         Turn off power to all power board outputs.
         """
         self._send_and_receive({'power': False})
+
+    def set_output(self, output: PowerOutput, value: bool) -> None:
+        self.send_and_receive({
+            'power-output': output.value
+            'power-level': value,
+        })
 
     def set_start_led(self, value: bool):
         """Set the state of the start LED."""

--- a/robot/power.py
+++ b/robot/power.py
@@ -12,12 +12,12 @@ LOGGER = logging.getLogger(__name__)
 class PowerOutput(enum.Enum):
     """An enumeration of the outputs on the power board."""
 
-    HIGH_POWER_0 = 0
-    HIGH_POWER_1 = 1
-    LOW_POWER_0 = 2
-    LOW_POWER_1 = 3
-    LOW_POWER_2 = 4
-    LOW_POWER_3 = 5
+    H0 = 0
+    H1 = 1
+    L0 = 2
+    L1 = 3
+    L2 = 4
+    L3 = 5
 
 
 class PowerBoard(Board):

--- a/robot/power.py
+++ b/robot/power.py
@@ -60,6 +60,8 @@ class PowerBoard(Board):
         """
         Turn on and off individual power outputs.
         """
+        if not isinstance(value, bool):
+            raise TypeError("Value must be a boolean (True/False)")
         self._send_and_receive({
             'power-output': output.value,
             'power-level': value,

--- a/robot/power.py
+++ b/robot/power.py
@@ -12,12 +12,12 @@ LOGGER = logging.getLogger(__name__)
 class PowerOutput(enum.Enum):
     """An enumeration of the outputs on the power board."""
 
-    HIGH_POWER_1 = 0
-    HIGH_POWER_2 = 1
-    LOW_POWER_1 = 2
-    LOW_POWER_2 = 3
-    LOW_POWER_3 = 4
-    LOW_POWER_4 = 5
+    HIGH_POWER_0 = 0
+    HIGH_POWER_1 = 1
+    LOW_POWER_0 = 2
+    LOW_POWER_1 = 3
+    LOW_POWER_2 = 4
+    LOW_POWER_3 = 5
 
 
 class PowerBoard(Board):

--- a/tests/test_power.py
+++ b/tests/test_power.py
@@ -142,7 +142,7 @@ class PowerBoardTest(MockRobotDFactoryMixin, unittest.TestCase):
 
     def test_separate_power_on(self):
         self.power_board.clear_queue()
-        self.robot.power_board.power_on_output(PowerOutput.HIGH_POWER_1)
+        self.robot.power_board.power_on_output(PowerOutput.H1)
         msg = self.power_board.message_queue.get()
         self.assertIn('power-output', msg)
         self.assertIn('power-level', msg)
@@ -151,7 +151,7 @@ class PowerBoardTest(MockRobotDFactoryMixin, unittest.TestCase):
 
     def test_separate_power_off(self):
         self.power_board.clear_queue()
-        self.robot.power_board.power_off_output(PowerOutput.HIGH_POWER_1)
+        self.robot.power_board.power_off_output(PowerOutput.H1)
         msg = self.power_board.message_queue.get()
         self.assertIn('power-output', msg)
         self.assertIn('power-level', msg)

--- a/tests/test_power.py
+++ b/tests/test_power.py
@@ -146,5 +146,5 @@ class PowerBoardTest(MockRobotDFactoryMixin, unittest.TestCase):
         msg = self.power_board.message_queue.get()
         self.assertIn('power-output', msg)
         self.assertIn('power-level', msg)
-        self.assertEqual(msg['power-output'], 0)
+        self.assertEqual(msg['power-output'], 1)
         self.assertEqual(msg['power-level'], True)

--- a/tests/test_power.py
+++ b/tests/test_power.py
@@ -2,7 +2,7 @@ import time
 import unittest
 from unittest import mock
 
-from robot.power import PowerBoard
+from robot.power import PowerBoard, PowerOutput
 from robot.robot import Robot
 from tests.mock_robotd import MockRobotDFactoryMixin
 
@@ -139,3 +139,12 @@ class PowerBoardTest(MockRobotDFactoryMixin, unittest.TestCase):
             'duration': 500,
         })
         self.assertIsInstance(msg['buzz']['duration'], int)
+
+    def test_separate_power(self):
+        self.power_board.clear_queue()
+        self.robot.power_board.set_output(PowerOutput.HIGH_POWER_1, True)
+        msg = self.power_board.message_queue.get()
+        self.assertIn('power-output', msg)
+        self.assertIn('power-level', msg)
+        self.assertEqual(msg['power-output'], 0)
+        self.assertEqual(msg['power-level'], True)


### PR DESCRIPTION
Implements support for controlling separate power outputs, exposed by https://github.com/sourcebots/robotd/pull/51