### PR TITLE
Replace thread killing with SIGALRM

### DIFF
--- a/robot/game.py
+++ b/robot/game.py
@@ -1,10 +1,8 @@
 import logging
-import time
+import signal
 from enum import Enum
-from threading import Thread
 from typing import NewType
 
-import _thread
 from robot.board import Board
 
 Zone = NewType('Zone', int)
@@ -12,26 +10,20 @@ Zone = NewType('Zone', int)
 LOGGER = logging.getLogger(__name__)
 
 
+def timeout_handler(signum, stack):
+    """
+    Handle the `SIGALRM` to kill the current process.
+    """
+    raise SystemExit("Timeout expired: Game Over!")
+
+
 def kill_after_delay(timeout_seconds):
     """
     Interrupts main process after the given delay.
     """
 
-    end_time = time.time() + timeout_seconds
-
-    def worker():
-        while time.time() < end_time:
-            remaining = end_time - time.time()
-            time.sleep(max(remaining, 0.01))
-
-        LOGGER.info("Timeout %rs expired: Game over!", timeout_seconds)
-
-        # Interrupt the main thread to kill the user code
-        _thread.interrupt_main()  # type: ignore
-
-    worker_thread = Thread(target=worker, daemon=True)
-    worker_thread.start()
-    return worker_thread
+    signal.signal(signal.SIGALRM, timeout_handler)
+    signal.alarm(timeout_seconds)
 
 
 class GameMode(Enum):


### PR DESCRIPTION
Rather then using the system clock, which has issues with the Pis CPU changing its clock speed. This implementation using `SIGALRM`, which doesn't have this issue:

> SIGALRM is sent when real or clock time elapses

https://en.wikipedia.org/wiki/Signal_(IPC)#SIGALRM