### PR TITLE
Expand copyright to contributors

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,11 @@
 MIT License
 
-Copyright (c) 2017 Source Bots
+Copyright (c) 2017 Alistair Lynn, Andrew Barrett-Sprot,
+                   Andy <andymin@commentitout.com>, Anton Nikitin, Jake Howard,
+                   Kier Davis, Peter Law, Thomas Leese
+              2018 Alex Lockwood, Alistair Lynn, Andrew Barrett-Sprot,
+                   Anton Nikitin, Dan Trickey, Jake Howard, James Seden Smith,
+                   Kier Davis, Peter Law
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This fixes the issue raised in https://github.com/sourcebots/robot-api/issues/105 that "Source Bots" isn't a well defined entity and thus isn't really in a position to own copyright.

Note: I'm not expecting to get review from all the individuals here, I think it's reasonable to assume that they're happy with the MIT license since they've contributed into the repo which already had it present.

Fixes https://github.com/sourcebots/robot-api/issues/105.